### PR TITLE
feat: support other types of release metadata

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,7 @@ name: Test action
 
 on:
   push:
+  pull_request:
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ The `isometry/setup-generic-tool` action is designed to make the use of generic 
 
 **Optional** Override tool name, if it doesn't match the repo name
 
+### `asset` input
+
+**Optional** Override asset name, if it doesn't match the tool name
+
 ### `version` input
 
 **Optional** Version of tool to install (default: `latest`; example: `v1.2.3`)

--- a/action.yaml
+++ b/action.yaml
@@ -10,6 +10,10 @@ inputs:
     description: Override tool name, if it doesn't match the repo name
     required: false
     default: ""
+  asset:
+    description: Override asset name, if it doesn't match the tool name
+    required: false
+    default: ""
   version:
     description: Version of tool to install
     required: false
@@ -31,5 +35,6 @@ runs:
         NAME: ${{ inputs.name }}
         VERSION: ${{ inputs.version }}
         TOOL: ${{ inputs.tool }}
+        ASSET: ${{ inputs.asset }}
       run: |
-        "${GITHUB_ACTION_PATH}/setup.sh" "${NAME}" "${VERSION}" "${TOOL}"
+        "${GITHUB_ACTION_PATH}/setup.sh" "${NAME}" "${VERSION}" "${TOOL}" "${ASSET}"

--- a/setup.sh
+++ b/setup.sh
@@ -31,6 +31,8 @@ IFS='/' read -r OWNER REPO <<< "${REPO_NAME}"
 # Set tool name if not provided as third argument
 TOOL_NAME="${3:-${REPO}}"
 
+ASSET_NAME_INPUT="${4:-${TOOL_NAME}}"
+
 # Validate tool name
 [[ ! "${TOOL_NAME}" =~ ^[-A-Za-z0-9]+$ ]] && error "Invalid tool name"
 
@@ -87,7 +89,7 @@ if [[ -d "${TOOL_CACHE_DIR}" ]]; then
     info "Found ${TOOL_NAME} ${VERSION} in ${TOOL_CACHE_DIR}"
 else
     info "Searching for ${TOOL_NAME} ${VERSION} for ${PLATFORM}/${ARCH}"
-    ASSET_PATTERN="^${TOOL_NAME}.+${PLATFORM}.+${ARCH_PATTERN}([.](tar[.]gz|zip))?\$"
+    ASSET_PATTERN="^${ASSET_NAME_INPUT}.+${PLATFORM}.+${ARCH_PATTERN}([.](tar[.]gz|zip))?\$"
     mapfile -t ASSETS < <(jq -r --arg pattern "${ASSET_PATTERN}" '.assets[] | select(.name | test($pattern; "i")) | .name' <<< "${RELEASE_DATA}")
 
     : "${ASSETS:?No matching release asset found}"

--- a/setup.sh
+++ b/setup.sh
@@ -40,6 +40,12 @@ ASSET_NAME_INPUT="${4:-${TOOL_NAME}}"
 PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 
+if [[ ${PLATFORM} == "darwin" ]]; then
+    PLATFORM_PATTERN="(darwin|macos)"
+else
+    PLATFORM_PATTERN="(${PLATFORM})"
+fi
+
 # Convert architecture to common formats
 case "${ARCH}" in
     "aarch64"|"arm64")
@@ -89,7 +95,7 @@ if [[ -d "${TOOL_CACHE_DIR}" ]]; then
     info "Found ${TOOL_NAME} ${VERSION} in ${TOOL_CACHE_DIR}"
 else
     info "Searching for ${TOOL_NAME} ${VERSION} for ${PLATFORM}/${ARCH}"
-    ASSET_PATTERN="^${ASSET_NAME_INPUT}.+${PLATFORM}.+${ARCH_PATTERN}([.](tar[.]gz|zip))?\$"
+    ASSET_PATTERN="^${ASSET_NAME_INPUT}.+${PLATFORM_PATTERN}.+${ARCH_PATTERN}([.](tar[.]gz|zip))?\$"
     mapfile -t ASSETS < <(jq -r --arg pattern "${ASSET_PATTERN}" '.assets[] | select(.name | test($pattern; "i")) | .name' <<< "${RELEASE_DATA}")
 
     : "${ASSETS:?No matching release asset found}"


### PR DESCRIPTION
This should fix the test workflow:
```
      - uses: ./
        with:
          name: cli/cli
          tool: gh
```

where `gh` macOS binaries don't have `darwin` in the name, but `gh_2.74.2_macOS_amd64.zip`.

And the crane download:
```
        uses: isometry/setup-generic-tool@1a641516469c4d463e5ec9eaed53b54e5a7864fc # v1.2.0
        with:
          name: google/go-containerregistry
          version: v0.20.6
          tool: crane
          asset: go-containerregistry
```

by adding the last name, since the metadata doesn't contain the tool name (`crane` in this case), but another asset name `go-containerregistry`.

Also, enabled test to run on Pull Request and now they are successful
https://github.com/varlucian/setup-generic-tool/actions/runs/15819968722/job/44586767080