### PR TITLE
fix: log extraction only if debug is enabled

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -121,9 +121,10 @@ else
 
     if [[ "${ASSET_NAME}" == *.zip ]]; then
         info "Extracting ${ASSET_NAME}"
-        unzip -q "${ASSET_NAME}"
+        [[ "${RUNNER_DEBUG:-0}" == "1" ]] && unzip "${ASSET_NAME}" || unzip -q "${ASSET_NAME}"
     elif [[ "${ASSET_NAME}" == *.tar.gz ]]; then
         info "Extracting ${ASSET_NAME}"
+        [[ "${RUNNER_DEBUG:-0}" == "1" ]] && tar tzf "${ASSET_NAME}"
         tar xzf "${ASSET_NAME}"
     fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 
 # Function to run commands only in debug mode
 debug() {
-    [[ "${RUNNER_DEBUG:-0}" == "1" ]] && "$@"
+    if [[ "${RUNNER_DEBUG:-0}" == "1" ]]; then
+        "$@" | sed 's/^/DEBUG: /g'
+    fi
 }
 
 # Enable debug mode if RUNNER_DEBUG is 1

--- a/setup.sh
+++ b/setup.sh
@@ -124,7 +124,6 @@ else
         unzip -q "${ASSET_NAME}"
     elif [[ "${ASSET_NAME}" == *.tar.gz ]]; then
         info "Extracting ${ASSET_NAME}"
-        tar tzf "${ASSET_NAME}"
         tar xzf "${ASSET_NAME}"
     fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -2,8 +2,13 @@
 
 set -euo pipefail
 
+# Function to run commands only in debug mode
+debug() {
+    [[ "${RUNNER_DEBUG:-0}" == "1" ]] && "$@"
+}
+
 # Enable debug mode if RUNNER_DEBUG is 1
-[[ "${RUNNER_DEBUG:-0}" == "1" ]] && set -x
+debug set -x
 
 # Function to print error and exit
 error() {
@@ -121,10 +126,11 @@ else
 
     if [[ "${ASSET_NAME}" == *.zip ]]; then
         info "Extracting ${ASSET_NAME}"
-        [[ "${RUNNER_DEBUG:-0}" == "1" ]] && unzip "${ASSET_NAME}" || unzip -q "${ASSET_NAME}"
+        debug unzip -l "${ASSET_NAME}"
+        unzip -q "${ASSET_NAME}"
     elif [[ "${ASSET_NAME}" == *.tar.gz ]]; then
         info "Extracting ${ASSET_NAME}"
-        [[ "${RUNNER_DEBUG:-0}" == "1" ]] && tar tzf "${ASSET_NAME}"
+        debug tar tzf "${ASSET_NAME}"
         tar xzf "${ASSET_NAME}"
     fi
 


### PR DESCRIPTION
The zip extraction is silent (`zip -q`) but the tar extraction lists all files before extraction. This resolves the discrepancy between both.