### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: Test action
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/isometry/setup-generic-tool/security/code-scanning/3](https://github.com/isometry/setup-generic-tool/security/code-scanning/3)

To fix the problem, we should add a `permissions` block to restrict the GITHUB_TOKEN's access for this workflow. The block can be added either at the workflow root level (before the `jobs:` key) or at the job level. Given there is only one job, adding at the root is clean and guarantees coverage for future jobs. "contents: read" is the minimal permission allowing access to the repository's content and code, which is necessary for actions/checkout and all the operations in this workflow. 

The change is simply to add the following block:

```yaml
permissions:
  contents: read
```

This should be inserted after the `name:` (line 1) and before the `on:` (line 3) in the provided YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
